### PR TITLE
fix: remove explicit Identifiable conformance on DateEvent

### DIFF
--- a/TimeTrace-iOS/Models/DateEvent.swift
+++ b/TimeTrace-iOS/Models/DateEvent.swift
@@ -50,9 +50,6 @@ final class DateEvent {
     }
 }
 
-// SwiftUI 的 sheet、全屏页、删除确认框都要用 Identifiable，声明的 id 正好是 Int64
-extension DateEvent: Identifiable {}
-
 // 给新事件发不重复的自增编号
 enum EventIDGenerator {
     private static let key = "EventIDGenerator.next"


### PR DESCRIPTION
移除 `DateEvent` 上显式的 `Identifiable` 协议遵循声明，因为 SwiftData 的 `@Model` 宏已自动提供该遵循