### PR TITLE
fix: reuse background-cropped images in the editor preview

### DIFF
--- a/TimeTrace-iOS/Detail/Components/EventPosterView.swift
+++ b/TimeTrace-iOS/Detail/Components/EventPosterView.swift
@@ -10,7 +10,7 @@ struct PosterContent: View {
     var scale: CGFloat = 1.0
     // 首次进入时的一次性文字滑入量
     var firstSlideX: CGFloat = 0
-    // 编辑预览传入后台已按预览框比例裁好的图，海报自己就不再 scaledToFill
+    // 编辑预览传入后台裁好的图片
     var preparedBackground: UIImage? = nil
 
     // 横移距离

--- a/TimeTrace-iOS/Detail/Components/EventPosterView.swift
+++ b/TimeTrace-iOS/Detail/Components/EventPosterView.swift
@@ -10,6 +10,8 @@ struct PosterContent: View {
     var scale: CGFloat = 1.0
     // 首次进入时的一次性文字滑入量
     var firstSlideX: CGFloat = 0
+    // 编辑预览传入后台已按预览框比例裁好的图，海报自己就不再 scaledToFill
+    var preparedBackground: UIImage? = nil
 
     // 横移距离
     @Environment(\.tabSlideOffset) private var slideOffset
@@ -19,7 +21,7 @@ struct PosterContent: View {
             // 只有文字滑动
             ZStack {
                 // 背景图满屏
-                EventBackgroundView(event: event)
+                EventBackgroundView(event: event, preparedImage: preparedBackground)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .clipped()
                 // 黑的遮罩

--- a/TimeTrace-iOS/Editor/EditorScreen.swift
+++ b/TimeTrace-iOS/Editor/EditorScreen.swift
@@ -14,6 +14,11 @@ struct EditorScreen: View {
     @State private var showDatePicker = false
     // 背景图的文件路径，没选就是 nil
     @State private var backgroundImageName: String?
+    // 后台按预览比例裁好的图，预览直接铺，不再自己 scaledToFill
+    @State private var pinnedPreviewImage: UIImage?
+    @State private var posterPreviewImage: UIImage?
+    // 编辑页内容宽度，给全屏预览裁切用
+    @State private var previewContentWidth: CGFloat = 0
     // 照片选择器选中的
     @State private var pickerItem: PhotosPickerItem?
     // 是否弹出系统相册
@@ -67,18 +72,28 @@ struct EditorScreen: View {
         }
     }
 
-    // 图片后台处理
+    // 图片后台处理：缩图存盘，同时裁出置顶卡和全屏预览要用的图
     private func handlePickedImage(_ newItem: PhotosPickerItem?) {
         guard let newItem else { return }
+        let posterAspect = posterPreviewAspect
         Task {
-            let name = await Task.detached(priority: .userInitiated) { () -> String? in
+            let prepared = await Task.detached(priority: .userInitiated) { () -> EditorPreviewImages? in
                 guard let data = try? await newItem.loadTransferable(type: Data.self),
                       let uiImage = UIImage(data: data) else { return nil }
-                return ImageUtils.saveBackground(uiImage)
+                return ImageUtils.prepareEditorBackground(uiImage, posterAspect: posterAspect)
             }.value
-            backgroundImageName = name
+            if let prepared {
+                backgroundImageName = prepared.fileName
+                pinnedPreviewImage = prepared.pinned
+                posterPreviewImage = prepared.poster
+            }
             pickerItem = nil
         }
+    }
+
+    // 全屏预览框是定高 500，宽跟编辑页内容区走
+    private var posterPreviewAspect: CGFloat {
+        max(previewContentWidth > 0 ? previewContentWidth : 360, 1) / 500
     }
 
     // 标题输入框
@@ -241,7 +256,7 @@ struct EditorScreen: View {
                 .foregroundStyle(TimeTracePalette.secondary)
             // 外层锁死宽度，防止卡片内部 aspectRatio 在滚动视图里被图片自然尺寸撑宽
             GeometryReader { geo in
-                PinnedEventCard(event: previewEvent) {}
+                PinnedEventCard(event: previewEvent, preparedBackground: pinnedPreviewImage)
                     .frame(width: geo.size.width, height: geo.size.height)
             }
             .aspectRatio(16.0 / 9.0, contentMode: .fit)
@@ -261,10 +276,13 @@ struct EditorScreen: View {
                     days: TimeUtils.daysBetween(targetDate: previewEvent.targetDate),
                     showsTime: false,
                     // 预览不是真全屏，字号按比例缩小
-                    scale: 0.55
+                    scale: 0.55,
+                    preparedBackground: posterPreviewImage
                 )
                 .frame(width: geo.size.width, height: 500)
                 .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                .onAppear { previewContentWidth = geo.size.width }
+                .onChange(of: geo.size.width) { _, width in previewContentWidth = width }
             }
             .frame(height: 500)
         }

--- a/TimeTrace-iOS/Editor/EditorScreen.swift
+++ b/TimeTrace-iOS/Editor/EditorScreen.swift
@@ -14,8 +14,10 @@ struct EditorScreen: View {
     @State private var showDatePicker = false
     // 背景图的文件路径，没选就是 nil
     @State private var backgroundImageName: String?
-    // 后台按预览比例裁好的图，预览直接铺，不再自己 scaledToFill
+    // 预览直接使用后台异步裁切好的图片
+    // 置顶的
     @State private var pinnedPreviewImage: UIImage?
+    // 全屏的
     @State private var posterPreviewImage: UIImage?
     // 编辑页内容宽度，给全屏预览裁切用
     @State private var previewContentWidth: CGFloat = 0
@@ -72,14 +74,18 @@ struct EditorScreen: View {
         }
     }
 
-    // 图片后台处理：缩图存盘，同时裁出置顶卡和全屏预览要用的图
+    // 同时裁出置顶卡和全屏预览的图
     private func handlePickedImage(_ newItem: PhotosPickerItem?) {
+        // 检查
         guard let newItem else { return }
         let posterAspect = posterPreviewAspect
+        // 独立
         Task {
             let prepared = await Task.detached(priority: .userInitiated) { () -> EditorPreviewImages? in
                 guard let data = try? await newItem.loadTransferable(type: Data.self),
                       let uiImage = UIImage(data: data) else { return nil }
+                      // 拿工具类处理，本来的裁切接口
+                      // 调用原先 return ImageUtils.saveBackground(uiImage) 没用的裁切功能
                 return ImageUtils.prepareEditorBackground(uiImage, posterAspect: posterAspect)
             }.value
             if let prepared {

--- a/TimeTrace-iOS/Home/Components/EventCard.swift
+++ b/TimeTrace-iOS/Home/Components/EventCard.swift
@@ -6,6 +6,8 @@ import UIKit
 struct PinnedEventCard: View {
     let event: DateEvent
     var onClick: () -> Void = {}
+    // 编辑预览传入后台已按 16:9 裁好的图，卡片自己就不再 scaledToFill
+    var preparedBackground: UIImage? = nil
 
     var body: some View {
         Button(action: onClick) {
@@ -14,7 +16,7 @@ struct PinnedEventCard: View {
             GeometryReader { proxy in
                 ZStack(alignment: .bottomLeading) {
                     // 图片层铺满卡片，超出部分裁剪
-                    EventBackgroundView(event: event)
+                    EventBackgroundView(event: event, preparedImage: preparedBackground)
                         .frame(width: proxy.size.width, height: proxy.size.height)
                         .clipped()
 
@@ -229,10 +231,16 @@ enum BackgroundImageCache {
 
 struct EventBackgroundView: View {
     let event: DateEvent
+    // 已经按容器比例裁好的图，有的话直接铺，不再 scaledToFill
+    var preparedImage: UIImage? = nil
 
     var body: some View {
         Group {
-            if let name = event.backgroundImageName {
+            if let preparedImage {
+                Image(uiImage: preparedImage)
+                    .resizable()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let name = event.backgroundImageName {
                 cachedImage(name: name)
             } else {
                 TimeTracePalette.surfaceVariant

--- a/TimeTrace-iOS/Home/Components/EventCard.swift
+++ b/TimeTrace-iOS/Home/Components/EventCard.swift
@@ -6,7 +6,7 @@ import UIKit
 struct PinnedEventCard: View {
     let event: DateEvent
     var onClick: () -> Void = {}
-    // 编辑预览传入后台已按 16:9 裁好的图，卡片自己就不再 scaledToFill
+    // 编辑预览传入后台裁好的图
     var preparedBackground: UIImage? = nil
 
     var body: some View {
@@ -231,7 +231,7 @@ enum BackgroundImageCache {
 
 struct EventBackgroundView: View {
     let event: DateEvent
-    // 已经按容器比例裁好的图，有的话直接铺，不再 scaledToFill
+    // 已经按容器比例裁好的图
     var preparedImage: UIImage? = nil
 
     var body: some View {

--- a/TimeTrace-iOS/Support/ImageUtils.swift
+++ b/TimeTrace-iOS/Support/ImageUtils.swift
@@ -1,5 +1,12 @@
 import UIKit
 
+// 编辑页预览用的两张已裁切图，连同写入磁盘的文件名一起从后台任务带回来
+nonisolated struct EditorPreviewImages: @unchecked Sendable {
+    let fileName: String
+    let pinned: UIImage
+    let poster: UIImage
+}
+
 // 图片尺寸控制工具
 enum ImageUtils {
     // 缩到最大边不超过 maxDimension，避免原图直接存盘导致体积和渲染过大
@@ -14,16 +21,43 @@ enum ImageUtils {
         }
     }
 
+    // 按目标宽高比居中裁切，顺带把最长边限制住，给预览直接铺
+    nonisolated static func centerCropped(_ image: UIImage, aspectRatio: CGFloat, maxDimension: CGFloat = 1600) -> UIImage {
+        let size = image.size
+        guard size.width > 0, size.height > 0, aspectRatio > 0 else { return image }
+
+        let imageRatio = size.width / size.height
+        var cropWidth = size.width
+        var cropHeight = size.height
+        if imageRatio > aspectRatio {
+            cropWidth = size.height * aspectRatio
+        } else if imageRatio < aspectRatio {
+            cropHeight = size.width / aspectRatio
+        }
+
+        let longest = max(cropWidth, cropHeight)
+        let outputScale = longest > maxDimension ? maxDimension / longest : 1
+        let target = CGSize(width: cropWidth * outputScale, height: cropHeight * outputScale)
+        let renderer = UIGraphicsImageRenderer(size: target)
+        return renderer.image { _ in
+            let drawRect = CGRect(
+                x: -(size.width - cropWidth) / 2 * outputScale,
+                y: -(size.height - cropHeight) / 2 * outputScale,
+                width: size.width * outputScale,
+                height: size.height * outputScale
+            )
+            image.draw(in: drawRect)
+        }
+    }
+
     // 背景图存放的目录
     nonisolated static var backgroundsDirectory: URL {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }
 
-    // 存一张背景图，成功就返回文件名
-    // 只记文件名不记完整路径，因为 App 每次重装容器路径都会变，记全路径会让老图全部失效
-    nonisolated static func saveBackground(_ image: UIImage) -> String? {
-        let resized = downscaled(image)
-        guard let jpeg = resized.jpegData(compressionQuality: 0.85) else { return nil }
+    // 把已经处理好的图写成 JPEG，成功就返回文件名
+    nonisolated static func writeBackground(_ image: UIImage) -> String? {
+        guard let jpeg = image.jpegData(compressionQuality: 0.85) else { return nil }
         let fileName = "bg-\(UUID().uuidString).jpg"
         do {
             try jpeg.write(to: backgroundsDirectory.appendingPathComponent(fileName))
@@ -31,6 +65,23 @@ enum ImageUtils {
         } catch {
             return nil
         }
+    }
+
+    // 存一张背景图，成功就返回文件名
+    // 只记文件名不记完整路径，因为 App 每次重装容器路径都会变，记全路径会让老图全部失效
+    nonisolated static func saveBackground(_ image: UIImage) -> String? {
+        writeBackground(downscaled(image))
+    }
+
+    // 后台一次做完：缩图存盘，再按置顶卡 16:9 和全屏预览比例裁两张
+    nonisolated static func prepareEditorBackground(_ image: UIImage, posterAspect: CGFloat) -> EditorPreviewImages? {
+        let source = downscaled(image)
+        guard let fileName = writeBackground(source) else { return nil }
+        return EditorPreviewImages(
+            fileName: fileName,
+            pinned: centerCropped(source, aspectRatio: 16.0 / 9.0),
+            poster: centerCropped(source, aspectRatio: posterAspect)
+        )
     }
 
     // 按存下来的名字把图读出来

--- a/TimeTrace-iOS/Support/ImageUtils.swift
+++ b/TimeTrace-iOS/Support/ImageUtils.swift
@@ -21,7 +21,7 @@ enum ImageUtils {
         }
     }
 
-    // 按目标宽高比居中裁切，顺带把最长边限制住，给预览直接铺
+    // 按目标宽高比居中裁切 把最长边限制住 给预览直接铺
     nonisolated static func centerCropped(_ image: UIImage, aspectRatio: CGFloat, maxDimension: CGFloat = 1600) -> UIImage {
         let size = image.size
         guard size.width > 0, size.height > 0, aspectRatio > 0 else { return image }
@@ -67,13 +67,12 @@ enum ImageUtils {
         }
     }
 
-    // 存一张背景图，成功就返回文件名
     // 只记文件名不记完整路径，因为 App 每次重装容器路径都会变，记全路径会让老图全部失效
     nonisolated static func saveBackground(_ image: UIImage) -> String? {
         writeBackground(downscaled(image))
     }
 
-    // 后台一次做完：缩图存盘，再按置顶卡 16:9 和全屏预览比例裁两张
+    // 缩图存盘 裁两张备用
     nonisolated static func prepareEditorBackground(_ image: UIImage, posterAspect: CGFloat) -> EditorPreviewImages? {
         let source = downscaled(image)
         guard let fileName = writeBackground(source) else { return nil }


### PR DESCRIPTION
## 改动

编辑时痕预览不再对背景图做一次 `scaledToFill` 裁切，改为直接使用选图后台任务已经按预览比例裁好的图。

- 选背景时，后台任务缩图存盘，并按置顶卡 16:9、全屏预览框比例各裁一张
- 编辑页两处预览直接铺这两张图，不再解码原图、也不再现场裁切
- 首页卡片和详情海报仍走磁盘原图 + `scaledToFill`，不受影响

## 测试

- `xcodebuild` 针对 iPhone 17 模拟器编译通过