### PR TITLE
fix: persist cropped previews and the full-size thumbnail

### DIFF
--- a/TimeTrace-iOS/Editor/EditorScreen.swift
+++ b/TimeTrace-iOS/Editor/EditorScreen.swift
@@ -74,7 +74,7 @@ struct EditorScreen: View {
         }
     }
 
-    // 同时裁出置顶卡和全屏预览的图
+    // 后台裁出置顶卡和全屏预览，并保存完整尺寸缩略图备用
     private func handlePickedImage(_ newItem: PhotosPickerItem?) {
         // 检查
         guard let newItem else { return }
@@ -84,8 +84,6 @@ struct EditorScreen: View {
             let prepared = await Task.detached(priority: .userInitiated) { () -> EditorPreviewImages? in
                 guard let data = try? await newItem.loadTransferable(type: Data.self),
                       let uiImage = UIImage(data: data) else { return nil }
-                      // 拿工具类处理，本来的裁切接口
-                      // 调用原先 return ImageUtils.saveBackground(uiImage) 没用的裁切功能
                 return ImageUtils.prepareEditorBackground(uiImage, posterAspect: posterAspect)
             }.value
             if let prepared {

--- a/TimeTrace-iOS/Support/ImageUtils.swift
+++ b/TimeTrace-iOS/Support/ImageUtils.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-// 编辑页预览用的两张已裁切图，连同写入磁盘的文件名一起从后台任务带回来
+// 编辑页预览用的两张已裁切图，fileName 指向完整尺寸缩略图
 nonisolated struct EditorPreviewImages: @unchecked Sendable {
     let fileName: String
     let pinned: UIImage
@@ -56,12 +56,13 @@ enum ImageUtils {
     }
 
     // 把已经处理好的图写成 JPEG，成功就返回文件名
-    nonisolated static func writeBackground(_ image: UIImage) -> String? {
+    @discardableResult
+    nonisolated static func writeBackground(_ image: UIImage, fileName: String? = nil) -> String? {
         guard let jpeg = image.jpegData(compressionQuality: 0.85) else { return nil }
-        let fileName = "bg-\(UUID().uuidString).jpg"
+        let name = fileName ?? "bg-\(UUID().uuidString).jpg"
         do {
-            try jpeg.write(to: backgroundsDirectory.appendingPathComponent(fileName))
-            return fileName
+            try jpeg.write(to: backgroundsDirectory.appendingPathComponent(name))
+            return name
         } catch {
             return nil
         }
@@ -72,14 +73,20 @@ enum ImageUtils {
         writeBackground(downscaled(image))
     }
 
-    // 缩图存盘 裁两张备用
+    // 后台一次做完：两张预览裁切落盘，再按原先那样存一份完整尺寸缩略图备用
     nonisolated static func prepareEditorBackground(_ image: UIImage, posterAspect: CGFloat) -> EditorPreviewImages? {
         let source = downscaled(image)
-        guard let fileName = writeBackground(source) else { return nil }
+        let pinned = centerCropped(source, aspectRatio: 16.0 / 9.0)
+        let poster = centerCropped(source, aspectRatio: posterAspect)
+        let id = UUID().uuidString
+        // 完整尺寸缩略图给首页、详情当备用，记录里只记这个名字
+        guard let fileName = writeBackground(source, fileName: "bg-\(id).jpg") else { return nil }
+        writeBackground(pinned, fileName: "bg-\(id)-pinned.jpg")
+        writeBackground(poster, fileName: "bg-\(id)-poster.jpg")
         return EditorPreviewImages(
             fileName: fileName,
-            pinned: centerCropped(source, aspectRatio: 16.0 / 9.0),
-            poster: centerCropped(source, aspectRatio: posterAspect)
+            pinned: pinned,
+            poster: poster
         )
     }
 


### PR DESCRIPTION
## 改动

选背景时除了两张预览裁切，再按原先方式保存一份完整尺寸缩略图备用。

- 后台任务落盘三张同组图片：`bg-{id}-pinned.jpg`、`bg-{id}-poster.jpg`、`bg-{id}.jpg`
- 事件记录仍只记完整缩略图文件名，首页卡片和详情海报继续用它做 `scaledToFill`
- 编辑预览依旧直接铺两张已裁切图

## 测试

- 未跑模拟器；改动限于选图存盘路径，不改变预览渲染逻辑